### PR TITLE
fix: 修复部署脚本还没执行完，后面脚本就已经输出的问题

### DIFF
--- a/scripts/deploy.docker.sh
+++ b/scripts/deploy.docker.sh
@@ -124,16 +124,25 @@ deploy_key_server() {
   # 读取本机环境变量
   ENV_VARS=$(export_env_vars)
 
-  ssh -o StrictHostKeyChecking=no "$SERVER_USER@$SERVER_IP" \
-    "$ENV_VARS
-    $(typeset -f); $action_func"
+#  ssh -o StrictHostKeyChecking=no "$SERVER_USER@$SERVER_IP" \
+#    "$ENV_VARS
+#    $(typeset -f); $action_func"
+#
+#  # 捕获 SSH 命令的退出状态
+#  # shellcheck disable=SC2181
+#  if [[ $? -ne 0 ]]; then
+#    echo "远程服务器部署失败"
+#    exit 1
+#  fi
 
-  # 捕获 SSH 命令的退出状态
-  # shellcheck disable=SC2181
-  if [[ $? -ne 0 ]]; then
-    echo "远程服务器部署失败"
+  if ! ssh -o StrictHostKeyChecking=no "$SERVER_USER@$SERVER_IP" \
+      "$ENV_VARS
+      $(typeset -f); $action_func"; then
+    echo "远程部署失败"
     exit 1
   fi
+
+
   echo "远程服务器部署成功"
 }
 
@@ -156,6 +165,7 @@ deploy_pwd_server() {
     echo "远程服务器部署失败"
     exit 1
   fi
+
   echo "远程服务器部署成功"
 }
 

--- a/scripts/deploy.docker.sh
+++ b/scripts/deploy.docker.sh
@@ -129,6 +129,7 @@ deploy_key_server() {
     $(typeset -f); $action_func"
 
   # 捕获 SSH 命令的退出状态
+  # shellcheck disable=SC2181
   if [[ $? -ne 0 ]]; then
     echo "远程服务器部署失败"
     exit 1
@@ -150,6 +151,7 @@ deploy_pwd_server() {
     $(typeset -f); $action_func"
 
   # 捕获 SSH 命令的退出状态
+  # shellcheck disable=SC2181
   if [[ $? -ne 0 ]]; then
     echo "远程服务器部署失败"
     exit 1

--- a/scripts/deploy.docker.sh
+++ b/scripts/deploy.docker.sh
@@ -127,6 +127,13 @@ deploy_key_server() {
   ssh -o StrictHostKeyChecking=no "$SERVER_USER@$SERVER_IP" \
     "$ENV_VARS
     $(typeset -f); $action_func"
+
+  # 捕获 SSH 命令的退出状态
+  if [[ $? -ne 0 ]]; then
+    echo "远程服务器部署失败"
+    exit 1
+  fi
+  echo "远程服务器部署成功"
 }
 
 deploy_pwd_server() {
@@ -141,6 +148,13 @@ deploy_pwd_server() {
     "$SERVER_USER@$SERVER_IP" \
     "$ENV_VARS
     $(typeset -f); $action_func"
+
+  # 捕获 SSH 命令的退出状态
+  if [[ $? -ne 0 ]]; then
+    echo "远程服务器部署失败"
+    exit 1
+  fi
+  echo "远程服务器部署成功"
 }
 
 


### PR DESCRIPTION
log_info "🚀🚀🚀 CD Deployment 执行完毕" 在 deploy_key_server deploy_server 执行完之前就开始执行的原因是：在 deploy_key_server 函数中使用了 ssh 远程执行 deploy_server，但是本地脚本并不会等待远程命令执行完再继续执行后续代码。

也就是说，虽然 ssh 命令在远程服务器上运行，但本地的 shell 并没有等待它完成，而是继续执行了本地脚本中的下一行代码。所以，log_info "🚀🚀🚀 CD Deployment 执行完毕" 会提前打印出来，即使远程的部署过程还没有结束。